### PR TITLE
Fix Hyprland Blur changes in config, add back battery to waybar

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -78,10 +78,12 @@ decoration {
     # See https://wiki.hyprland.org/Configuring/Variables/ for more
 
     rounding = 10
-    blur = yes
-    blur_size = 3
-    blur_passes = 1
-    blur_new_optimizations = on
+
+    blur {
+	enabled = yes
+        size = 3
+        passes = 1
+    }
 
     drop_shadow = yes
     shadow_range = 4

--- a/waybar/config
+++ b/waybar/config
@@ -14,6 +14,7 @@
         "network",
         "pulseaudio",
         "pulseaudio#mic",
+	"battery",
         "cpu",
         "memory",
 	"tray",


### PR DESCRIPTION
Battery module works fine in desktop even though there is no BAT0, it will just throw a warning that BAT0 does not exist and will not display the battery module